### PR TITLE
[analyzer] Add z-score normalization to firing rate utils

### DIFF
--- a/src/canns/analyzer/utils.py
+++ b/src/canns/analyzer/utils.py
@@ -147,21 +147,17 @@ def normalize_firing_rates(
             data_min = firing_rates.min()
             data_max = firing_rates.max()
 
-            # 检查分母是否为零，以避免除零错误
             if data_max - data_min != 0:
                 min_max_scaled_data = (firing_rates - data_min) / (data_max - data_min)
             else:
-                # 如果所有值都相同，则归一化结果为全零
                 min_max_scaled_data = np.zeros_like(firing_rates, dtype=float)
             return min_max_scaled_data
         case "z_score":
             data_mean = firing_rates.mean()
             data_std = firing_rates.std()
 
-            # 检查标准差是否为零，以避免除零错误
             if data_std != 0:
                 z_score_scaled_data = (firing_rates - data_mean) / data_std
             else:
-                # 如果标准差为零（所有值都相同），则标准化结果为全零
                 z_score_scaled_data = np.zeros_like(firing_rates, dtype=float)
             return z_score_scaled_data

--- a/src/canns/analyzer/utils.py
+++ b/src/canns/analyzer/utils.py
@@ -119,6 +119,7 @@ def firing_rate_to_spike_train(
 
 def normalize_firing_rates(
     firing_rates: np.ndarray,
+    method: str = "min_max",
 ) -> np.ndarray:
     """
     Normalizes firing rates to a range of [0, 1] based on the maximum firing rate.
@@ -126,6 +127,10 @@ def normalize_firing_rates(
     Args:
         firing_rates (np.ndarray):
             2D array of shape (timesteps_rate, num_neurons) with firing rates in dt_rate.
+        method (str):
+            Normalization method, either 'min_max' or 'z_score'.
+            - 'min_max': Normalizes to the range [0, 1].
+            - 'z_score': Normalizes to have mean 0 and standard deviation 1.
 
     Returns:
         np.ndarray:
@@ -134,8 +139,29 @@ def normalize_firing_rates(
     if firing_rates.ndim != 2:
         raise ValueError("firing_rates must be a 2D array.")
 
-    max_firing_rate = np.max(firing_rates)
-    if max_firing_rate == 0:
-        return np.zeros_like(firing_rates)
+    if method not in ["min_max", "z_score"]:
+        raise ValueError("Normalization method must be 'min_max' or 'z_score'.")
 
-    return firing_rates / max_firing_rate
+    match method:
+        case "min_max":
+            data_min = firing_rates.min()
+            data_max = firing_rates.max()
+
+            # 检查分母是否为零，以避免除零错误
+            if data_max - data_min != 0:
+                min_max_scaled_data = (firing_rates - data_min) / (data_max - data_min)
+            else:
+                # 如果所有值都相同，则归一化结果为全零
+                min_max_scaled_data = np.zeros_like(firing_rates, dtype=float)
+            return min_max_scaled_data
+        case "z_score":
+            data_mean = firing_rates.mean()
+            data_std = firing_rates.std()
+
+            # 检查标准差是否为零，以避免除零错误
+            if data_std != 0:
+                z_score_scaled_data = (firing_rates - data_mean) / data_std
+            else:
+                # 如果标准差为零（所有值都相同），则标准化结果为全零
+                z_score_scaled_data = np.zeros_like(firing_rates, dtype=float)
+            return z_score_scaled_data

--- a/src/canns/analyzer/visualize.py
+++ b/src/canns/analyzer/visualize.py
@@ -756,7 +756,6 @@ def tuning_curve(
             if pref_stim is not None and neuron_idx < len(pref_stim):
                 label += f" (pref_stim={pref_stim[neuron_idx]:.2f})"
 
-
             # Plot the curve. Bins that were empty will have a `nan` mean,
             # which matplotlib handles gracefully (it won't plot them).
             ax.plot(bin_centers, mean_rates, label=label, **kwargs)

--- a/tests/analyzer/test_visualize.py
+++ b/tests/analyzer/test_visualize.py
@@ -33,7 +33,7 @@ def test_energy_landscape_1d():
 
     output_path_static = 'test_energy_landscape_1d_static.png'
     energy_landscape_1d_static(
-        {'u': (cann.x, us[0]), 'Iext': (cann.x, inps[0])},
+        {'u': (cann.x, us[int(task_pc.total_steps/2)]), 'Iext': (cann.x, inps[int(task_pc.total_steps/2)])},
         title='Population Coding 1D (Static)',
         xlabel='State',
         ylabel='Activity',
@@ -79,7 +79,7 @@ def test_energy_landscape_2d():
 
     output_path_static = 'test_energy_landscape_2d_static.png'
     energy_landscape_2d_static(
-        z_data=us[0],
+        z_data=us[int(task_pc.total_steps/2)],
         title='Population Coding 2D (Static)',
         xlabel='State X',
         ylabel='State Y',
@@ -162,7 +162,7 @@ def test_average_firing_rate():
     average_firing_rate_plot(
         rs,
         mode='population',
-        title='Average Firing Rate',
+        title='Average Firing Rate (Population)',
         dt=0.1,
         save_path=output_path_population,
         show=False,
@@ -172,7 +172,7 @@ def test_average_firing_rate():
     average_firing_rate_plot(
         rs,
         mode='per_neuron',
-        title='Average Firing Rate',
+        title='Average Firing Rate (Per Neuron)',
         dt=0.1,
         save_path=output_path_per_neuron,
         show=False,


### PR DESCRIPTION
This pull request introduces enhancements to the normalization of firing rates, minor visual adjustments in plotting, and updates to test cases for better clarity and accuracy. The most significant changes include adding support for multiple normalization methods, refining visualization labels, and improving test data selection.

### Enhancements to firing rate normalization:
* [`src/canns/analyzer/utils.py`](diffhunk://#diff-aa0fbc9713d09db8069dd613315c0fc365705a461641c6f2fddfa930f7c52dcaR122-R133): Added a `method` parameter to `normalize_firing_rates` to support both 'min_max' and 'z_score' normalization methods. Implemented logic to handle edge cases like zero variance or constant values in the data. [[1]](diffhunk://#diff-aa0fbc9713d09db8069dd613315c0fc365705a461641c6f2fddfa930f7c52dcaR122-R133) [[2]](diffhunk://#diff-aa0fbc9713d09db8069dd613315c0fc365705a461641c6f2fddfa930f7c52dcaL137-R167)

### Visual adjustments in plotting:
* [`src/canns/analyzer/visualize.py`](diffhunk://#diff-ebef6937bc0608d720f6c1555b23bd0b0a20061f7218caa0d999f9f339fb01a4L759): Removed unnecessary blank line in `tuning_curve` function for cleaner code formatting.

### Updates to test cases:
* [`tests/analyzer/test_visualize.py`](diffhunk://#diff-b71b7275dee21198077fc2ba3796463bb2375de03fef2b0735aa11b79a26274dL36-R36): Updated test cases to use midpoint data (`us[int(task_pc.total_steps/2)]`) instead of initial data for `energy_landscape_1d_static` and `energy_landscape_2d_static`. Improved plot titles for `average_firing_rate_plot` to specify modes ('Population' and 'Per Neuron'). [[1]](diffhunk://#diff-b71b7275dee21198077fc2ba3796463bb2375de03fef2b0735aa11b79a26274dL36-R36) [[2]](diffhunk://#diff-b71b7275dee21198077fc2ba3796463bb2375de03fef2b0735aa11b79a26274dL82-R82) [[3]](diffhunk://#diff-b71b7275dee21198077fc2ba3796463bb2375de03fef2b0735aa11b79a26274dL165-R165) [[4]](diffhunk://#diff-b71b7275dee21198077fc2ba3796463bb2375de03fef2b0735aa11b79a26274dL175-R175)

## Summary by Sourcery

Add configurable normalization methods to firing rate utilities, improve edge-case handling, clean up plotting code formatting, and clarify visualization tests with midpoint data and specific plot titles.

New Features:
- Introduce a method parameter in normalize_firing_rates to support both min_max and z_score normalization.

Enhancements:
- Handle zero-variance and constant-value edge cases in both normalization methods.
- Remove an unnecessary blank line in the tuning_curve plotting function for cleaner code.

Tests:
- Update energy landscape tests to use midpoint data instead of initial values.
- Enhance average firing rate plot tests with mode-specific titles for Population and Per Neuron.