### PR TITLE
[docs] Enable GitHub Pages auto-deployment and fix CI security issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [ master ]  # Still test PRs but don't deploy
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-docs:
     name: Build documentation
@@ -37,9 +48,33 @@ jobs:
         cd docs
         sphinx-build -b html . _build/html
     
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    
     - name: Upload documentation artifacts
       uses: actions/upload-artifact@v4
       with:
         name: documentation
         path: docs/_build/html
         retention-days: 30
+    
+    - name: Upload to GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      with:
+        path: docs/_build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,13 +8,11 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
@@ -73,6 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-docs
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     
     steps:
     - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,8 @@ jobs:
     - name: Setup Pages
       uses: actions/configure-pages@v4
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      with:
+        enablement: true
     
     - name: Upload documentation artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add automatic GitHub Pages deployment for documentation
- Implement proper CI security permissions and concurrency controls
- Enable GitHub Pages automatically in repository settings

## Changes
- Added GitHub Pages deployment job with proper permissions
- Configured concurrency controls to prevent deployment conflicts  
- Added Pages setup step to enable GitHub Pages automatically
- Improved CI security with minimal required permissions

## Test plan
- Verify documentation builds successfully
- Confirm GitHub Pages deployment works on master branch pushes
- Test that Pages are enabled automatically in repository settings