### PR TITLE
[docs] Fix documentation website: SVG favicon and API navigation

### DIFF
--- a/docs/autoapi/index.rst
+++ b/docs/autoapi/index.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+This page contains auto-generated API reference documentation [#f1]_.
+
+.. toctree::
+   :titlesonly:
+
+   src/canns/index
+
+
+.. [#f1] Created with `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,9 @@ autodoc_typehints_description_target = 'documented'
 html_theme = 'furo'
 html_static_path = ['_static']
 
+# Favicon
+html_favicon = '_static/logo.svg'
+
 # Custom CSS files
 html_css_files = [
     'custom.css',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,18 +57,20 @@ autoapi_type = 'python'
 autoapi_template_dir = '_templates/autoapi'
 autoapi_options = [
     'members',
-    'undoc-members',
+    'undoc-members', 
     'show-inheritance',
     'show-module-summary',
     'special-members',
     'imported-members',
 ]
+autoapi_generate_api_docs = True
+autoapi_add_toctree_entry = True
 # Suppress duplicate object warnings
 suppress_warnings = ['autosummary', 'autosummary.import_cycle']
 autoapi_ignore = ['*/_version.py', '*/py.typed', '**/py.typed']
 autoapi_python_class_content = 'both'  # Include both class and __init__ docstrings
 autoapi_member_order = 'groupwise'
-autoapi_keep_files = False
+autoapi_keep_files = True
 # Additional settings to avoid import resolution errors
 autoapi_python_use_implicit_namespaces = True
 


### PR DESCRIPTION
## Summary
- Configure SVG favicon for documentation website
- Fix API documentation navigation to show complete module tree
- Improve AutoAPI configuration for better documentation generation

## Changes Made
### 1. SVG Favicon Configuration
- Added `html_favicon = '_static/logo.svg'` to display project logo as website icon
- Favicon will now appear in browser tabs and bookmarks

### 2. API Documentation Navigation Fix
- Set `autoapi_keep_files = True` to preserve generated RST files
- Added `autoapi_generate_api_docs = True` and `autoapi_add_toctree_entry = True`
- Manually fixed `autoapi/index.rst` toctree to include `src/canns/index`
- API Reference now shows complete navigable module tree in sidebar

### 3. Improved AutoAPI Configuration
- Enhanced documentation generation settings
- Fixed empty API Reference navigation issue
- All modules now properly linked: analyzer, models, task, trainer, typing, etc.

## Test Plan
- [x] Verify favicon displays correctly in browser
- [x] Confirm API documentation navigation shows all modules
- [x] Test that all API documentation pages are accessible
- [x] Validate documentation builds successfully in CI

## Before/After
**Before**: API Reference page had empty navigation, no favicon
**After**: Complete API module tree navigation, SVG favicon displayed

The documentation website now provides a professional appearance with proper branding and fully functional API reference navigation.