### PR TITLE
[pipeline] add shared pipeline base

### DIFF
--- a/src/canns/pipeline/__init__.py
+++ b/src/canns/pipeline/__init__.py
@@ -6,6 +6,7 @@ accessible to experimental researchers without requiring detailed knowledge of
 the underlying implementations.
 """
 
+from ._base import Pipeline
 from .theta_sweep import (
     ThetaSweepPipeline,
     batch_process_trajectories,
@@ -13,6 +14,7 @@ from .theta_sweep import (
 )
 
 __all__ = [
+    "Pipeline",
     "ThetaSweepPipeline",
     "load_trajectory_from_csv",
     "batch_process_trajectories",

--- a/src/canns/pipeline/_base.py
+++ b/src/canns/pipeline/_base.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+
+class Pipeline(ABC):
+    """Abstract base class for CANNS pipelines.
+
+    Pipelines orchestrate multi-step workflows (data preparation, model execution,
+    visualization, etc.). This base class standardizes how we manage results and
+    output directories so derived pipelines can focus on domain-specific logic.
+    """
+
+    def __init__(self) -> None:
+        self.results: dict[str, Any] | None = None
+        self.output_dir: Path | None = None
+
+    @abstractmethod
+    def run(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Execute the pipeline and return a mapping of generated artifacts."""
+
+    def reset(self) -> None:
+        """Reset stored state so the pipeline can be executed again cleanly."""
+        self.results = None
+        self.output_dir = None
+
+    def prepare_output_dir(self, output_dir: str | Path, *, create: bool = True) -> Path:
+        """Validate and optionally create the output directory for derived pipelines."""
+        path = Path(output_dir)
+        if create:
+            path.mkdir(parents=True, exist_ok=True)
+        self.output_dir = path
+        return path
+
+    def set_results(self, results: dict[str, Any]) -> dict[str, Any]:
+        """Store pipeline results and return them for convenient chaining."""
+        self.results = results
+        return results
+
+    def get_results(self) -> dict[str, Any]:
+        """Return stored results or raise if the pipeline has not been executed."""
+        if self.results is None:
+            raise RuntimeError("Pipeline results are not available; call run() first.")
+        return self.results
+
+    def has_results(self) -> bool:
+        """Check whether the pipeline has already produced results."""
+        return self.results is not None

--- a/src/canns/pipeline/theta_sweep.py
+++ b/src/canns/pipeline/theta_sweep.py
@@ -24,9 +24,10 @@ from ..models.basic.theta_sweep_model import (
     calculate_theta_modulation,
 )
 from ..task.spatial_navigation import SpatialNavigationTask
+from ._base import Pipeline
 
 
-class ThetaSweepPipeline:
+class ThetaSweepPipeline(Pipeline):
     """
     High-level pipeline for theta sweep analysis of external trajectory data.
 
@@ -71,6 +72,7 @@ class ThetaSweepPipeline:
             theta_params: Parameters for theta modulation. If None, uses defaults
             spatial_nav_params: Additional parameters for SpatialNavigationTask. If None, uses defaults
         """
+        super().__init__()
         # Store trajectory data
         self.trajectory_data = np.array(trajectory_data)
         self.times = np.array(times) if times is not None else None
@@ -101,7 +103,6 @@ class ThetaSweepPipeline:
         self.spatial_nav_task = None
         self.direction_network = None
         self.grid_network = None
-        self.results = None
 
     def _validate_trajectory_data(self):
         """Validate input trajectory data."""
@@ -294,12 +295,12 @@ class ThetaSweepPipeline:
         Returns:
             Dictionary containing paths to generated files and analysis data
         """
+        self.reset()
         if verbose:
             print("🚀 Starting Theta Sweep Pipeline...")
 
         # Create output directory
-        output_path = Path(output_dir)
-        output_path.mkdir(parents=True, exist_ok=True)
+        output_path = self.prepare_output_dir(output_dir)
 
         # Setup pipeline components
         if verbose:
@@ -329,8 +330,7 @@ class ThetaSweepPipeline:
             print("✅ Pipeline completed successfully!")
             print(f"📁 Results saved to: {output_path.absolute()}")
 
-        self.results = outputs
-        return outputs
+        return self.set_results(outputs)
 
     def _generate_plots(self, output_path: Path, show_plots: bool, verbose: bool) -> dict[str, str]:
         """Generate analysis plots."""

--- a/tests/pipeline/test_base.py
+++ b/tests/pipeline/test_base.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from canns.pipeline import Pipeline
+
+
+class DummyPipeline(Pipeline):
+    def run(self, output_dir: str | Path, *, flag: bool = False) -> dict[str, str | bool]:
+        path = self.prepare_output_dir(output_dir)
+        result = {"output": str(path), "flag": flag}
+        return self.set_results(result)
+
+
+def test_pipeline_helpers_manage_state(tmp_path):
+    pipeline = DummyPipeline()
+    output_dir = tmp_path / "results"
+
+    assert pipeline.output_dir is None
+    assert not pipeline.has_results()
+
+    results = pipeline.run(output_dir=output_dir, flag=True)
+
+    assert output_dir.exists()
+    assert pipeline.output_dir == output_dir
+    assert results == {"output": str(output_dir), "flag": True}
+    assert pipeline.get_results() == results
+    assert pipeline.has_results()
+
+    pipeline.reset()
+    assert pipeline.output_dir is None
+    assert not pipeline.has_results()
+
+    with pytest.raises(RuntimeError):
+        pipeline.get_results()


### PR DESCRIPTION
## Summary
- add shared pipeline abstract base class with helpers
- refactor theta sweep pipeline to inherit the base helpers
- export the base and add regression coverage for helper methods

## Testing
- uv run pytest tests/pipeline -q