### PR TITLE
[trainer] Add Trainer base class

### DIFF
--- a/src/canns/trainer/__init__.py
+++ b/src/canns/trainer/__init__.py
@@ -1,11 +1,14 @@
 """
 Training utilities for CANNS models.
 
-Currently exposes a unified ``HebbianTrainer`` with built-in progress reporting.
+The module exposes the abstract ``Trainer`` base class and concrete implementations
+such as ``HebbianTrainer``.
 """
 
+from ._base import Trainer
 from .hebbian import HebbianTrainer
 
 __all__ = [
+    "Trainer",
     "HebbianTrainer",
 ]

--- a/src/canns/trainer/_base.py
+++ b/src/canns/trainer/_base.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Any
+
+
+class Trainer(ABC):
+    """Abstract base class for training utilities in CANNS."""
+
+    def __init__(
+        self,
+        model: Any | None = None,
+        *,
+        show_iteration_progress: bool = False,
+        compiled_prediction: bool = True,
+    ) -> None:
+        self.model = model
+        self.show_iteration_progress = show_iteration_progress
+        self.compiled_prediction = compiled_prediction
+
+    @abstractmethod
+    def train(self, train_data: Iterable[Any]) -> None:
+        """Train the associated model with the provided dataset."""
+
+    @abstractmethod
+    def predict(self, pattern: Any, *args: Any, **kwargs: Any) -> Any:
+        """Predict an output for a single pattern."""
+
+    def predict_batch(self, patterns: Iterable[Any], *args: Any, **kwargs: Any) -> list[Any]:
+        """Predict outputs for multiple patterns using ``predict``."""
+        return [self.predict(pattern, *args, **kwargs) for pattern in patterns]
+
+    def configure_progress(
+        self,
+        *,
+        show_iteration_progress: bool | None = None,
+        compiled_prediction: bool | None = None,
+    ) -> None:
+        """Update progress-related flags for derived trainers."""
+        if show_iteration_progress is not None:
+            self.show_iteration_progress = show_iteration_progress
+        if compiled_prediction is not None:
+            self.compiled_prediction = compiled_prediction

--- a/src/canns/trainer/hebbian.py
+++ b/src/canns/trainer/hebbian.py
@@ -7,11 +7,12 @@ import jax.numpy as jnp
 from tqdm import tqdm  # type: ignore
 
 from ..models.brain_inspired import BrainInspiredModel
+from ._base import Trainer
 
 __all__ = ["HebbianTrainer"]
 
 
-class HebbianTrainer:
+class HebbianTrainer(Trainer):
     """
     Generic Hebbian trainer with progress reporting.
 
@@ -70,9 +71,11 @@ class HebbianTrainer:
             prefer_generic: If True, use trainer's generic Hebbian rule when possible; otherwise
                 call the model's own implementation if available.
         """
-        self.model = model
-        self.show_iteration_progress = show_iteration_progress
-        self.compiled_prediction = compiled_prediction
+        super().__init__(
+            model=model,
+            show_iteration_progress=show_iteration_progress,
+            compiled_prediction=compiled_prediction,
+        )
         # Generic Hebbian config
         self.weight_attr = weight_attr
         self.subtract_mean = subtract_mean
@@ -461,15 +464,3 @@ class HebbianTrainer:
                 sample_pbar.close()
 
         return results
-
-    def configure_progress(
-        self,
-        *,
-        show_iteration_progress: bool | None = None,
-        compiled_prediction: bool | None = None,
-    ):
-        """Update progress-related flags without changing behavior."""
-        if show_iteration_progress is not None:
-            self.show_iteration_progress = show_iteration_progress
-        if compiled_prediction is not None:
-            self.compiled_prediction = compiled_prediction

--- a/tests/trainer/test_trainer_base.py
+++ b/tests/trainer/test_trainer_base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from canns.trainer import Trainer
+
+
+class DummyTrainer(Trainer):
+    def __init__(self) -> None:
+        super().__init__(model=None)
+        self.calls: list = []
+
+    def train(self, train_data) -> None:
+        self.calls.append(list(train_data))
+
+    def predict(self, pattern, *args, **kwargs):
+        return pattern
+
+
+def test_configure_progress_updates_flags() -> None:
+    trainer = DummyTrainer()
+    trainer.configure_progress(show_iteration_progress=True, compiled_prediction=False)
+
+    assert trainer.show_iteration_progress is True
+    assert trainer.compiled_prediction is False
+
+
+def test_predict_batch_delegates_to_predict() -> None:
+    trainer = DummyTrainer()
+    patterns = [1, 2, 3]
+
+    result = trainer.predict_batch(patterns)
+
+    assert result == patterns


### PR DESCRIPTION
## Summary
- introduce a reusable Trainer abstract base class to normalize progress controls and batch prediction helpers
- refactor HebbianTrainer to inherit from the new base and reuse shared flag handling
- add regression tests that cover configure_progress and predict_batch utilities

## Testing
- make test

## Summary by Sourcery

Introduce a Trainer abstract base class to centralize progress controls and batch prediction utilities, refactor HebbianTrainer to inherit from it, update module exports, and add tests for configure_progress and predict_batch.

New Features:
- Add Trainer abstract base class with train, predict, predict_batch, and configure_progress methods
- Expose Trainer in the trainer module’s public API

Enhancements:
- Refactor HebbianTrainer to inherit from Trainer and remove redundant progress and prediction logic

Tests:
- Add regression tests for Trainer.configure_progress and Trainer.predict_batch