### PR TITLE
[analyzer] Restore plotting docstrings

### DIFF
--- a/src/canns/analyzer/plotting/config.py
+++ b/src/canns/analyzer/plotting/config.py
@@ -10,7 +10,14 @@ __all__ = ["PlotConfig", "PlotConfigs"]
 
 @dataclass
 class PlotConfig:
-    """Unified configuration class for analyzer plotting helpers."""
+    """Unified configuration class for all plotting helpers in ``canns.analyzer``.
+
+    This mirrors the behaviour of the previous ``visualize`` module so that
+    reorganising the files does not affect the public API. The attributes map
+    directly to keyword arguments exposed by the high-level plotting functions,
+    allowing users to keep existing configuration objects unchanged after the
+    reorganisation.
+    """
 
     title: str = ""
     xlabel: str = ""
@@ -56,7 +63,11 @@ class PlotConfig:
 
 
 class PlotConfigs:
-    """Collection of high-level presets for common analyzer plots."""
+    """Collection of commonly used plot configurations.
+
+    These helpers mirror the presets that existed in ``canns.analyzer.visualize``
+    so that callers relying on them continue to receive the exact same defaults.
+    """
 
     @staticmethod
     def energy_landscape_1d_static(**kwargs: Any) -> PlotConfig:

--- a/src/canns/analyzer/plotting/spikes.py
+++ b/src/canns/analyzer/plotting/spikes.py
@@ -45,7 +45,24 @@ def raster_plot(
     show: bool = True,
     **kwargs: Any,
 ):
-    """Generate a raster plot for a spike train."""
+    """Generate a raster plot from a spike train matrix.
+
+    The explanatory text mirrors the former ``visualize`` module so callers see
+    the same guidance after the reorganisation.
+
+    Args:
+        spike_train: Boolean/integer array of shape ``(timesteps, neurons)``.
+        config: Optional :class:`PlotConfig` with shared styling options.
+        mode: Either ``"scatter"`` or ``"block"`` to pick the rendering style.
+        title: Plot title when ``config`` is not provided.
+        xlabel: X-axis label when ``config`` is not provided.
+        ylabel: Y-axis label when ``config`` is not provided.
+        figsize: Figure size forwarded to Matplotlib when creating the axes.
+        color: Spike colour (or "on" colour for block mode).
+        save_path: Optional path used to persist the plot.
+        show: Whether to display the plot interactively.
+        **kwargs: Additional keyword arguments passed through to Matplotlib.
+    """
 
     config = _ensure_plot_config(
         config,
@@ -132,7 +149,21 @@ def average_firing_rate_plot(
     show: bool = True,
     **kwargs: Any,
 ):
-    """Plot different summaries of average activity derived from a spike train."""
+    """Calculate and plot average neural activity from a spike train.
+
+    Args:
+        spike_train: Boolean/integer array of shape ``(timesteps, neurons)``.
+        dt: Simulation time step in seconds.
+        config: Optional :class:`PlotConfig` with styling overrides.
+        mode: One of ``"per_neuron"``, ``"population"`` or
+            ``"weighted_average"``.
+        weights: Neuron-wise weights required for ``"weighted_average"``.
+        title: Plot title when ``config`` is not provided.
+        figsize: Figure size forwarded to Matplotlib when creating the axes.
+        save_path: Optional path used to persist the plot.
+        show: Whether to display the plot interactively.
+        **kwargs: Additional keyword arguments forwarded to Matplotlib.
+    """
 
     config = _ensure_plot_config(
         config,

--- a/src/canns/analyzer/plotting/tuning.py
+++ b/src/canns/analyzer/plotting/tuning.py
@@ -67,7 +67,26 @@ def tuning_curve(
     show: bool = True,
     **kwargs: Any,
 ):
-    """Compute and plot tuning curves for one or more neurons."""
+    """Plot the tuning curve for one or more neurons.
+
+    The wording mirrors the original ``visualize`` module to avoid API drift and
+    to keep existing references valid.
+
+    Args:
+        stimulus: 1D array with the stimulus value at each time step.
+        firing_rates: 2D array of firing rates shaped ``(timesteps, neurons)``.
+        neuron_indices: Integer or iterable of neuron indices to analyse.
+        config: Optional :class:`PlotConfig` containing styling overrides.
+        pref_stim: Optional 1D array of preferred stimuli used in legend text.
+        num_bins: Number of bins when mapping stimulus to mean activity.
+        title: Plot title when ``config`` is not provided.
+        xlabel: X-axis label when ``config`` is not provided.
+        ylabel: Y-axis label when ``config`` is not provided.
+        figsize: Figure size forwarded to Matplotlib when creating the axes.
+        save_path: Optional location where the figure should be stored.
+        show: Whether to display the plot interactively.
+        **kwargs: Additional keyword arguments passed through to ``ax.plot``.
+    """
 
     config = _ensure_plot_config(
         config,


### PR DESCRIPTION
## Summary
- restore energy landscape docstrings and previous behaviour
- reuse legacy descriptions for spike and tuning helpers

## Testing
- uv run pytest tests/analyzer/test_plotting.py -q

## Summary by Sourcery

Restore legacy documentation and guidance for analyzer plotting helpers and enhance animation saving and rendering consistency

Enhancements:
- Restore detailed docstrings for 1D/2D static and animated energy plotting functions, raster_plot, average_firing_rate_plot, and tuning_curve to preserve previous behavior
- Update PlotConfig and PlotConfigs docstrings to mirror the former visualize module and maintain public API compatibility
- Introduce a configurable progress_bar_enabled flag for animation saving based on function arguments or PlotConfig
- Enhance 2D animation visualization by computing vmin/vmax, extracting initial frame data, standardizing colorbar creation, and refining grid and text styling