### PR TITLE
Fix polar plot title overflow in theta sweep animation

### DIFF
--- a/src/canns/analyzer/theta_sweep.py
+++ b/src/canns/analyzer/theta_sweep.py
@@ -867,6 +867,7 @@ def create_theta_sweep_animation(
     # Setup figure with 4 panels
     fig, axes = plt.subplots(1, 4, figsize=config.figsize, width_ratios=[1, 1, 1, 1])
     ax_traj, ax_dc_placeholder, ax_manifold, ax_realgc = axes
+    fig.tight_layout()
 
     # Panel 1: Animal Trajectory (static trajectory + dynamic dot, time in title)
     ax_traj.plot(data.position4ani[:, 0], data.position4ani[:, 1], color="#F18D00", lw=1)
@@ -888,7 +889,7 @@ def create_theta_sweep_animation(
     ax_dc.set_yticks([])
     ax_dc.set_xticks([0, np.pi / 2, np.pi, 3 * np.pi / 2])
     ax_dc.set_xticklabels(["0°", "90°", "180°", "270°"])
-    ax_dc.set_title("Direction Sweep")
+    ax_dc.set_title("Direction Sweep", pad=20)
 
     # Panel 3: Grid Cells on Manifold
     # Calculate manifold coordinates and static trajectory


### PR DESCRIPTION
## Summary
- Fix polar plot title being cut off at the top of the figure
- Add `pad=20` parameter to polar plot title to increase spacing
- Add `fig.tight_layout()` for automatic layout adjustment across all subplots

## Changes
- `src/canns/analyzer/theta_sweep.py`: Added title padding and tight layout

## Test plan
- [x] Run theta sweep animation examples
- [x] Verify "Direction Sweep" title is fully visible
- [x] Confirm layout looks good across all 4 panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)