### PR TITLE
Make TemplateMatching noise level configurable

### DIFF
--- a/src/canns/task/tracking.py
+++ b/src/canns/task/tracking.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 from collections.abc import Sequence
 
 import brainpy.math as bm
@@ -279,6 +280,12 @@ class TemplateMatching(TrackingTask):
     The noisy stimulus is generated as: stimulus + noise_level * A * randn()
     where A is the network's stimulus amplitude parameter and ``noise_level`` controls
     the relative noise strength (default ``0.1``).
+
+    Attributes:
+        A (float): Stimulus amplitude inherited from the underlying CANN
+            (``cann_instance.A``); sets the scale of the per-step Gaussian noise.
+        noise_level (float): Non-negative multiplier applied to ``A`` to set the
+            standard deviation of the per-step Gaussian noise.
     """
 
     def __init__(
@@ -300,10 +307,20 @@ class TemplateMatching(TrackingTask):
             duration (float | Quantity): The duration for which the noisy stimulus is presented.
             time_step (float | Quantity, optional): The simulation time step. Defaults to 0.1.
             noise_level (float, optional): Multiplier on the CANN amplitude ``A`` that
-                scales the per-step Gaussian noise. Must be non-negative. Defaults to 0.1.
+                scales the per-step Gaussian noise. Must be a finite, non-negative
+                scalar. Defaults to 0.1.
         """
-        if noise_level < 0:
-            raise ValueError(f"noise_level must be non-negative, got {noise_level!r}")
+        try:
+            noise_level = float(noise_level)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"noise_level must be a finite, non-negative float scalar, "
+                f"got {noise_level!r} of type {type(noise_level).__name__}"
+            ) from exc
+        if not math.isfinite(noise_level) or noise_level < 0.0:
+            raise ValueError(
+                f"noise_level must be a finite, non-negative float scalar, got {noise_level!r}"
+            )
         super().__init__(
             ndim=ndim,
             config={

--- a/src/canns/task/tracking.py
+++ b/src/canns/task/tracking.py
@@ -276,8 +276,9 @@ class TemplateMatching(TrackingTask):
     time step. The network must denoise the input and converge to the clean template,
     testing its attractor dynamics and noise robustness.
 
-    The noisy stimulus is generated as: stimulus + 0.1 * A * randn()
-    where A is the network's stimulus amplitude parameter.
+    The noisy stimulus is generated as: stimulus + noise_level * A * randn()
+    where A is the network's stimulus amplitude parameter and ``noise_level`` controls
+    the relative noise strength (default ``0.1``).
     """
 
     def __init__(
@@ -287,6 +288,7 @@ class TemplateMatching(TrackingTask):
         Iext: Iext_type,
         duration: time_type,
         time_step: time_type = 0.1,
+        noise_level: float = 0.1,
     ):
         """
         Initializes the Template Matching task.
@@ -297,7 +299,11 @@ class TemplateMatching(TrackingTask):
             Iext (float | Quantity): The position of the external input.
             duration (float | Quantity): The duration for which the noisy stimulus is presented.
             time_step (float | Quantity, optional): The simulation time step. Defaults to 0.1.
+            noise_level (float, optional): Multiplier on the CANN amplitude ``A`` that
+                scales the per-step Gaussian noise. Must be non-negative. Defaults to 0.1.
         """
+        if noise_level < 0:
+            raise ValueError(f"noise_level must be non-negative, got {noise_level!r}")
         super().__init__(
             ndim=ndim,
             config={
@@ -308,6 +314,7 @@ class TemplateMatching(TrackingTask):
             },
         )
         self.A = cann_instance.A  # The amplitude of the noise to be added.
+        self.noise_level = noise_level  # Multiplier for the per-step Gaussian noise.
 
     def get_data(self, progress_bar: bool = True):
         """
@@ -336,7 +343,7 @@ class TemplateMatching(TrackingTask):
             desc=f"<{type(self).__name__}>Generating Task data",
             disable=not progress_bar,
         ):
-            noise = 0.1 * self.A * np.random.randn(*self.shape)
+            noise = self.noise_level * self.A * np.random.randn(*self.shape)
             data[i] = stimulus + noise
 
         self.data = data
@@ -530,6 +537,7 @@ class TemplateMatching1D(TemplateMatching):
         Iext: Iext_type,
         duration: time_type,
         time_step: time_type = 0.1,
+        noise_level: float = 0.1,
     ):
         """
         Initializes the Template Matching task.
@@ -539,6 +547,8 @@ class TemplateMatching1D(TemplateMatching):
             Iext (float | Quantity): The position of the external input.
             duration (float | Quantity): The duration for which the noisy stimulus is presented.
             time_step (float | Quantity, optional): The simulation time step. Defaults to 0.1.
+            noise_level (float, optional): Multiplier on the CANN amplitude ``A`` that
+                scales the per-step Gaussian noise. Must be non-negative. Defaults to 0.1.
         """
         super().__init__(
             cann_instance=cann_instance,
@@ -546,6 +556,7 @@ class TemplateMatching1D(TemplateMatching):
             Iext=Iext,
             duration=duration,
             time_step=time_step,
+            noise_level=noise_level,
         )
 
 
@@ -732,6 +743,7 @@ class TemplateMatching2D(TemplateMatching):
         Iext: Iext_pair_type,
         duration: time_type,
         time_step: time_type = 0.1,
+        noise_level: float = 0.1,
     ):
         """
         Initializes the Template Matching task.
@@ -741,6 +753,8 @@ class TemplateMatching2D(TemplateMatching):
             Iext (tuple[float, float] | Quantity): The 2D position of the external input.
             duration (float | Quantity): The duration for which the noisy stimulus is presented.
             time_step (float | Quantity, optional): The simulation time step. Defaults to 0.1.
+            noise_level (float, optional): Multiplier on the CANN amplitude ``A`` that
+                scales the per-step Gaussian noise. Must be non-negative. Defaults to 0.1.
         """
         assert len(Iext) == 2, "Iext must be a tuple of two values for 2D tracking."
         super().__init__(
@@ -749,6 +763,7 @@ class TemplateMatching2D(TemplateMatching):
             Iext=Iext,
             duration=duration,
             time_step=time_step,
+            noise_level=noise_level,
         )
 
 

--- a/tests/unit/task/tracking/test_tracking1d.py
+++ b/tests/unit/task/tracking/test_tracking1d.py
@@ -94,8 +94,8 @@ def test_template_matching_1d_noise_level_zero_is_clean():
     # data has shape (T, *network_shape); compare each timestep to stimulus.
     for t in range(task.data.shape[0]):
         np.testing.assert_allclose(task.data[t], stimulus, atol=1e-12)
-    # And the across-time variance must be exactly zero (no noise term).
-    assert task.data.std(axis=0).max() == 0.0
+    # And the across-time std must be numerically zero (no noise term).
+    np.testing.assert_allclose(task.data.std(axis=0), 0.0, atol=1e-12)
 
 
 def test_template_matching_1d_noise_level_scales_std():
@@ -133,17 +133,41 @@ def test_template_matching_1d_noise_level_scales_std():
 
 
 def test_template_matching_1d_invalid_noise_level_rejected():
-    """Negative noise_level must be rejected at construction time."""
+    """Negative, non-finite, or non-numeric noise_level must be rejected."""
     bm.set_dt(dt=0.1)
     cann = CANN1D(num=64)
 
-    with pytest.raises(ValueError, match="noise_level must be non-negative"):
+    with pytest.raises(ValueError, match="noise_level must be a finite"):
         TemplateMatching1D(
             cann_instance=cann,
             Iext=0.0,
             duration=1.0,
             time_step=bm.get_dt(),
             noise_level=-0.01,
+        )
+    with pytest.raises(ValueError, match="noise_level must be a finite"):
+        TemplateMatching1D(
+            cann_instance=cann,
+            Iext=0.0,
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level=float("inf"),
+        )
+    with pytest.raises(ValueError, match="noise_level must be a finite"):
+        TemplateMatching1D(
+            cann_instance=cann,
+            Iext=0.0,
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level=float("nan"),
+        )
+    with pytest.raises(TypeError, match="noise_level must be a finite"):
+        TemplateMatching1D(
+            cann_instance=cann,
+            Iext=0.0,
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level="not a number",
         )
 
 

--- a/tests/unit/task/tracking/test_tracking1d.py
+++ b/tests/unit/task/tracking/test_tracking1d.py
@@ -1,9 +1,9 @@
-import brainpy as bp
 import brainpy.math as bm
+import numpy as np
+import pytest
 
-from canns.analyzer.visualization import energy_landscape_1d_animation
-from canns.task.tracking import PopulationCoding1D, TemplateMatching1D, SmoothTracking1D
 from canns.models.basic import CANN1D
+from canns.task.tracking import PopulationCoding1D, SmoothTracking1D, TemplateMatching1D
 
 
 def test_population_coding_1d():
@@ -74,6 +74,77 @@ def test_template_matching_1d():
     #     save_path='test_template_matching_1d.gif',
     #     show=False,
     # )
+
+
+def test_template_matching_1d_noise_level_zero_is_clean():
+    """noise_level=0 must produce the exact stimulus at every time step."""
+    bm.set_dt(dt=0.1)
+    cann = CANN1D(num=64)
+
+    task = TemplateMatching1D(
+        cann_instance=cann,
+        Iext=0.0,
+        duration=2.0,
+        time_step=bm.get_dt(),
+        noise_level=0.0,
+    )
+    task.get_data(progress_bar=False)
+
+    stimulus = task.get_stimulus_by_pos(task.Iext_sequence[0])
+    # data has shape (T, *network_shape); compare each timestep to stimulus.
+    for t in range(task.data.shape[0]):
+        np.testing.assert_allclose(task.data[t], stimulus, atol=1e-12)
+    # And the across-time variance must be exactly zero (no noise term).
+    assert task.data.std(axis=0).max() == 0.0
+
+
+def test_template_matching_1d_noise_level_scales_std():
+    """Doubling noise_level should roughly double the per-pixel noise std."""
+    bm.set_dt(dt=0.1)
+    cann = CANN1D(num=64)
+
+    np.random.seed(0)
+    task_low = TemplateMatching1D(
+        cann_instance=cann,
+        Iext=0.0,
+        duration=10.0,
+        time_step=bm.get_dt(),
+        noise_level=0.1,
+    )
+    task_low.get_data(progress_bar=False)
+
+    np.random.seed(0)
+    task_high = TemplateMatching1D(
+        cann_instance=cann,
+        Iext=0.0,
+        duration=10.0,
+        time_step=bm.get_dt(),
+        noise_level=0.3,
+    )
+    task_high.get_data(progress_bar=False)
+
+    # The per-time-step noise samples are drawn independently, so we compare
+    # the std of the *difference* between high-noise and low-noise data:
+    # (high - low) = (0.3 - 0.1) * A * randn() = 0.2 * A * randn().
+    diff = task_high.data - task_low.data
+    expected_std = 0.2 * cann.A
+    # Use a loose tolerance: ~5% on a 640-sample empirical std.
+    np.testing.assert_allclose(diff.std(), expected_std, rtol=0.10)
+
+
+def test_template_matching_1d_invalid_noise_level_rejected():
+    """Negative noise_level must be rejected at construction time."""
+    bm.set_dt(dt=0.1)
+    cann = CANN1D(num=64)
+
+    with pytest.raises(ValueError, match="noise_level must be non-negative"):
+        TemplateMatching1D(
+            cann_instance=cann,
+            Iext=0.0,
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level=-0.01,
+        )
 
 
 def test_smooth_tracking_1d():

--- a/tests/unit/task/tracking/test_tracking2d.py
+++ b/tests/unit/task/tracking/test_tracking2d.py
@@ -87,21 +87,37 @@ def test_template_matching_2d_noise_level_zero_is_clean():
     stimulus = task.get_stimulus_by_pos(task.Iext_sequence[0])
     for t in range(task.data.shape[0]):
         np.testing.assert_allclose(task.data[t], stimulus, atol=1e-12)
-    assert task.data.std(axis=0).max() == 0.0
+    np.testing.assert_allclose(task.data.std(axis=0), 0.0, atol=1e-12)
 
 
 def test_template_matching_2d_invalid_noise_level_rejected():
-    """Negative noise_level must be rejected at construction time."""
+    """Negative, non-finite, or non-numeric noise_level must be rejected."""
     bm.set_dt(dt=0.1)
     cann = CANN2D(length=4)
 
-    with pytest.raises(ValueError, match="noise_level must be non-negative"):
+    with pytest.raises(ValueError, match="noise_level must be a finite"):
         TemplateMatching2D(
             cann_instance=cann,
             Iext=[0.0, 0.0],
             duration=1.0,
             time_step=bm.get_dt(),
             noise_level=-0.5,
+        )
+    with pytest.raises(ValueError, match="noise_level must be a finite"):
+        TemplateMatching2D(
+            cann_instance=cann,
+            Iext=[0.0, 0.0],
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level=float("inf"),
+        )
+    with pytest.raises(TypeError, match="noise_level must be a finite"):
+        TemplateMatching2D(
+            cann_instance=cann,
+            Iext=[0.0, 0.0],
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level="not a number",
         )
 
 

--- a/tests/unit/task/tracking/test_tracking2d.py
+++ b/tests/unit/task/tracking/test_tracking2d.py
@@ -1,10 +1,9 @@
-import brainpy as bp
 import brainpy.math as bm
 import numpy as np
+import pytest
 
-from canns.analyzer.visualization import energy_landscape_2d_animation
-from canns.task.tracking import PopulationCoding2D, TemplateMatching2D, SmoothTracking2D
 from canns.models.basic import CANN2D, CANN2D_SFA
+from canns.task.tracking import PopulationCoding2D, SmoothTracking2D, TemplateMatching2D
 
 
 def test_population_coding_2d():
@@ -69,6 +68,41 @@ def test_template_matching_2d():
     #     save_path='test_template_matching_2d.gif',
     #     show=False,
     # )
+
+
+def test_template_matching_2d_noise_level_zero_is_clean():
+    """noise_level=0 must produce the exact 2D stimulus at every time step."""
+    bm.set_dt(dt=0.1)
+    cann = CANN2D(length=4)
+
+    task = TemplateMatching2D(
+        cann_instance=cann,
+        Iext=[0.0, 0.0],
+        duration=2.0,
+        time_step=bm.get_dt(),
+        noise_level=0.0,
+    )
+    task.get_data(progress_bar=False)
+
+    stimulus = task.get_stimulus_by_pos(task.Iext_sequence[0])
+    for t in range(task.data.shape[0]):
+        np.testing.assert_allclose(task.data[t], stimulus, atol=1e-12)
+    assert task.data.std(axis=0).max() == 0.0
+
+
+def test_template_matching_2d_invalid_noise_level_rejected():
+    """Negative noise_level must be rejected at construction time."""
+    bm.set_dt(dt=0.1)
+    cann = CANN2D(length=4)
+
+    with pytest.raises(ValueError, match="noise_level must be non-negative"):
+        TemplateMatching2D(
+            cann_instance=cann,
+            Iext=[0.0, 0.0],
+            duration=1.0,
+            time_step=bm.get_dt(),
+            noise_level=-0.5,
+        )
 
 
 def test_smooth_tracking_2d():


### PR DESCRIPTION
## Summary

The per-step Gaussian noise added by `TemplateMatching` (and its
`TemplateMatching1D` / `TemplateMatching2D` subclasses) was hard-coded
to `0.1 * A * randn()` inside `get_data()`. Callers had no way to
scale that noise from outside the task.

Promote it to an explicit `noise_level` constructor argument, defaulting
to `0.1` to preserve the previous behavior. Negative values are rejected
at construction time.

## Changes

- `TemplateMatching.__init__` gains `noise_level: float = 0.1` (must be
  non-negative). `get_data()` multiplies `randn()` by `self.noise_level`
  instead of the literal `0.1`.
- `TemplateMatching1D` / `TemplateMatching2D` forward `noise_level`
  through to the base class.
- Update class docstring to reflect the new parameter.

## Tests

Add unit tests under `tests/unit/task/tracking/`:

- `test_template_matching_1d_noise_level_zero_is_clean`:
  `noise_level=0` produces a noise-free constant stimulus.
- `test_template_matching_1d_noise_level_scales_std`:
  doubling `noise_level` roughly doubles the per-pixel noise std
  (verified by comparing two runs with the same RNG seed).
- `test_template_matching_1d_invalid_noise_level_rejected`:
  negative `noise_level` is rejected with `ValueError`.
- Same two coverage tests for the 2D variant.

All 11 tests in the tracking task suite pass, and the full
`uv run pytest -m "not slow"` run is green (139 passed, 4 skipped).

## Backward compatibility

`noise_level` defaults to `0.1`, so existing callers see identical
behavior. No public API is removed or renamed.

## Summary by Sourcery

Make the per-step Gaussian noise level in template matching tracking tasks configurable and validate its value.

New Features:
- Add a configurable noise_level parameter to TemplateMatching and its 1D/2D variants to control per-step Gaussian noise strength.

Bug Fixes:
- Reject negative noise_level values at construction time to prevent invalid noise configurations.

Enhancements:
- Document the noise_level parameter in TemplateMatching docstrings and use it when generating noisy stimuli instead of a hard-coded constant.

Tests:
- Add 1D and 2D template matching tests to verify zero-noise behavior, statistical scaling of noise with noise_level, and validation of invalid noise levels.